### PR TITLE
Classify subclasses based on skills and buffs

### DIFF
--- a/backend/meter_logs/services.py
+++ b/backend/meter_logs/services.py
@@ -391,6 +391,8 @@ def format_db_data(data: dict):
                     "is_dead": True if entry["is_dead"] == 1 else False,
                     "party_num": party_num,
                     "local_player": is_local_player,
+                    "skills": player_skills,
+                    "buffs": player_buffs,
                 }
             )
 

--- a/backend/meter_logs/services.py
+++ b/backend/meter_logs/services.py
@@ -115,6 +115,204 @@ def parse_db_file(db_file_path):
     return consolidated_data
 
 
+def process_skills(skill_info: dict, buff_dict: dict) -> tuple[dict, dict]:
+    """
+    Return a dictionary of skills with related buff information and a dictionary
+    of (de)buffs for a single entity.
+    """
+    # Filter out some irrelevant keys
+    player_skills = {
+        skill_ID: {
+            "name": info["name"],
+            "totalDamage": info["totalDamage"],
+            "maxDamageCast": info["maxDamageCast"],
+            "buffedBySupport": info["buffedBySupport"],
+            "buffedByIdentity": info["buffedByIdentity"],
+            "debuffedBySupport": info["debuffedBySupport"],
+            "casts": info["casts"],
+            "hits": info["hits"],
+            "crits": info["crits"],
+            "backAttacks": info["backAttacks"],
+            "frontAttacks": info["frontAttacks"],
+            "dps": info["dps"],
+            "buffs": info["buffedBy"] | info["debuffedBy"],
+        }
+        for (skill_ID, info) in skill_info.items()
+    }
+
+    # Get unique buff IDs
+    buff_IDs = [
+        buff_ID for skill in player_skills.values() for buff_ID in skill["buffs"]
+    ]
+    buff_IDs = list(set(buff_IDs))
+
+    player_buffs = {}
+    for buff_ID in buff_IDs:
+        if buff_ID not in buff_dict:
+            # Probably hidden (de)buff, skip
+            continue
+
+        # Get amount of damage done by each skill with this buff and sum
+        skill_damage = [
+            skill["buffs"].get(buff_ID, 0) for skill in player_skills.values()
+        ]
+        player_buffs[buff_ID] = {
+            "name": buff_dict[buff_ID]["source"]["name"],
+            "damage": sum(skill_damage),
+        }
+
+    return player_skills, player_buffs
+
+
+def classify_subclass(
+    entity: dict, player_skills: dict, player_buffs: dict, encounter: dict
+) -> str:
+    """Return the subclass of a player based on their entity entry"""
+
+    def _check_buff(buff_name: str) -> bool:
+        return any([buff_name in info["name"] for info in player_buffs.values()])
+
+    # Figure out class
+    player_class = entity["class"]
+
+    if player_class == "Berserker":
+        # Check if you have the Mayhem self skill buff
+        return "Mayhem" if _check_buff("Mayhem") else "Berserker's Technique"
+    elif player_class == "Destroyer":
+        # Look for skill "18030" special "Basic 3 Chain Hits" and does high damage split
+        return (
+            "Gravity Training"
+            if player_skills.get("18030", {"dps": 0})["dps"] / entity["dps"] > 0.3
+            else "Rage Hammer"
+        )
+    elif player_class == "Gunlancer":
+        # First check if they're Princess Maker
+        if entity["dps"] / encounter["dps"] < 0.05:
+            return "Princess Maker"
+        else:
+            # Looking for set
+            return (
+                "Combat Readiness"
+                if _check_buff("Hallucination")
+                or _check_buff("Enhanced Magick Addiction")
+                else "Lone Knight"
+            )
+    elif player_class == "Paladin":
+        # Checking if this person does okay damage
+        return "Judgment" if entity["dps"] / encounter["dps"] > 0.1 else "Blessed Aura"
+    elif player_class == "Slayer":
+        # Looking for the "Predator" skill self buff
+        return "Predator" if _check_buff("Predator") else "Punisher"
+    elif player_class == "Arcanist":
+        # Uses the "Emperor" skill to decide spec
+        return (
+            "Order of the Emperor"
+            if "19282" in player_skills.keys()
+            else "Empress's Grace"
+        )
+    elif player_class == "Summoner":
+        # Check if "20290" Kelsion, is in skills
+        return (
+            "Communication Overflow"
+            if "20290" in player_skills.keys()
+            else "Master Summoner"
+        )
+
+    elif player_class == "Bard":
+        # Check if they're doing okay damage
+        return (
+            "True Courage"
+            if entity["dps"] / encounter["dps"] > 0.1
+            else "Desperate Salvation"
+        )
+    elif player_class == "Sorceress":
+        # Looking for "Igniter" self buff
+        return "Igniter" if _check_buff("Igniter") else "Reflux"
+    elif player_class == "Wardancer":
+        # Looking for esoteric skill names
+        return (
+            "Esoteric Skill Enhancement"
+            if any(
+                [
+                    "Esoteric Skill: " in skill_info["name"]
+                    for skill_info in player_skills.values()
+                ]
+            )
+            else "First Intention"
+        )
+    elif player_class == "Scrapper":
+        # This one is weird where the Shock Training buff is ID "500224" but it doesn't have a name
+        return (
+            "Shock Training"
+            if "500224" in player_buffs.keys()
+            else "Ultimate Skill: Taijutsu"
+        )
+    elif player_class == "Soulfist":
+        # A weird one where the RS Hype is ID "240250" but it doesn't have a name
+        return "Robust Spirit" if "240250" in player_buffs.keys() else "Energy Overflow"
+    elif player_class == "Glaivier":
+        # Look for the "Pinnacle" skill self buff
+        return "Pinnacle" if _check_buff("Pinnacle") else "Control"
+    elif player_class == "Striker":
+        # Looking for the skill ID "39110", Call of the Wind God
+        return "Esoteric Flurry" if "39110" in player_skills.keys() else "Deathblow"
+    elif player_class == "Breaker":
+        # Looking for the skill "47020" Asura Destruction Basic Attack
+        return "Asura's Path" if "47020" in player_skills.keys() else "Brawl King Storm"
+    elif player_class == "Deathblade":
+        # Check if "25402" RE Death Trance exists and does damage
+        return (
+            "Remaining Energy"
+            if player_skills.get("25402", {"dps": 0})["dps"] / entity["dps"] > 0.1
+            else "Surge"
+        )
+    elif player_class == "Shadowhunter":
+        # Looking for Demonic Impulse self buff
+        return (
+            "Demonic Impulse"
+            if _check_buff("Demonic Impulse")
+            else "Perfect Suppression"
+        )
+    elif player_class == "Reaper":
+        # Checking for the "Lunar Voice" self buff
+        return "Lunar Voice" if _check_buff("Lunar Voice") else "Hunger"
+    elif player_class == "Souleater":
+        # Checking for "Soul Snatch" self buff
+        return "Night's Edge" if _check_buff("Soul Snatch") else "Full Moon Harvester"
+    elif player_class == "Sharpshooter":
+        # Look for Loyal Companion skill self buff
+        return "Loyal Companion" if _check_buff("Loyal Companion") else "Death Strike"
+    elif player_class == "Deadeye":
+        # Look for the "Enhanced Weapon" self skill buff
+        return "Enhanced Weapon" if _check_buff("Enhanced Weapon") else "Pistoleer"
+    elif player_class == "Artillerist":
+        # Looking for "30260" Barrage: Focus Fire and doing more than 10% damage
+        return (
+            "Barrage Enhancement"
+            if player_skills.get("30260", {"dps": 0})["dps"] / entity["dps"] > 0.1
+            else "Firepower Enhancement"
+        )
+    elif player_class == "Machinist":
+        # Look for Evolutionary Legacy skill self buff
+        return (
+            "Evolutionary Legacy"
+            if _check_buff("Evolutionary Legacy")
+            else "Arthetinean Skill"
+        )
+    elif player_class == "Gunslinger":
+        # Looking for Sharpshooter skill
+        return "Peacemaker" if "38110" in player_skills.keys() else "Time to Hunt"
+
+    elif player_class == "Artist":
+        # Checks if they're doing okay damage
+        return "Recurrence" if entity["dps"] / encounter["dps"] > 0.1 else "Full Bloom"
+    elif player_class == "Aeromancer":
+        # Check for Wind Fury buff
+        return "Wind Fury" if _check_buff("Wind Fury") else "Drizzle"
+    else:
+        return "Unknown"
+
+
 def format_db_data(data: dict):
     all_formatted_data = []
     all_player_data = []
@@ -135,6 +333,15 @@ def format_db_data(data: dict):
 
         misc_data = json.loads(value["encounter"]["misc"])
         party_info = misc_data.get("partyInfo", {})
+
+        # Parsed and combined dictionaries
+        buffs = json.loads(value["encounter"].get("buffs", "{}"))
+        debuffs = json.loads(value["encounter"].get("debuffs", "{}"))
+        buff_dict = buffs | debuffs
+
+        # Check if (de)buffs is empty
+        if len(buff_dict.keys()) == 0:
+            continue
 
         npc_id = None
         max_boss_hp = None
@@ -161,6 +368,12 @@ def format_db_data(data: dict):
             if is_local_player:
                 local_players.add(entry["name"])
 
+            skill_info = json.loads(entry["skills"])
+            player_skills, player_buffs = process_skills(skill_info, buff_dict)
+            subclass = classify_subclass(
+                entry, player_skills, player_buffs, value["encounter"]
+            )
+
             player_data.append(
                 {
                     "name": entry["name"],
@@ -168,7 +381,7 @@ def format_db_data(data: dict):
                     "class_id": (
                         None if (entry["class_id"] == 0 or None) else entry["class_id"]
                     ),
-                    "subclass": None,  # NEED TO IMPLEMENT A WAY TO CHECK SUBCLASS
+                    "subclass": subclass,
                     "dps": entry["dps"],
                     "gear_score": (
                         None


### PR DESCRIPTION
Adapted raided.pro code to classify subclasses based on skills and buffs for each player. 

This required the processing of skills and buffs, which are now also saved to the player table. The data saved is largely pared down from the raw data, intending only to support per skill/per buff displays as is typical on the  meter. 

Notably missing is per cast information (timing, buffs, and damage; this takes a lot of space), tripod information (could add but not sure if needed), and buff info (icon, description, etc; could be stored but it can also be queried from just a buff ID). 

Future work should allow flexible classification criteria based on date (patch) as well as T4/T3 split. This should be done by modifying the classify_subclass function. We would not expect additional information nor returning anything other than a string and as such the API for the function should never change.